### PR TITLE
IDEMPIERE-6989 Distributed Cache: Redis - add docker-compose harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Desktop.ini
 *.zip
 .idea/
 *.iml
+
+# IDEMPIERE-6989 redis-cluster harness — bundle JARs staged by build-dropins.sh
+redis-cluster/dropins/*.jar

--- a/redis-cluster/.env.example
+++ b/redis-cluster/.env.example
@@ -1,0 +1,14 @@
+# Reference for tunable env vars. Copy to .env to override docker-compose
+# defaults (compose auto-loads .env from this folder).
+
+# --- Path to your iDempiere source checkout (read by build-dropins.sh, NOT compose) ---
+# IDEMPIERE_SRC=/Users/you/GitHub/idempiere-fork
+
+# --- iDempiere image tag ---
+# IDEMPIERE_IMAGE=idempiereofficial/idempiere:12-release
+
+# --- Postgres password (must match DB_ADMIN_PASS on iDempiere) ---
+# POSTGRES_PASSWORD=postgres
+
+# --- Timezone (default UTC) ---
+# TZ=Europe/Bratislava

--- a/redis-cluster/.env.example
+++ b/redis-cluster/.env.example
@@ -5,7 +5,7 @@
 # IDEMPIERE_SRC=/Users/you/GitHub/idempiere-fork
 
 # --- iDempiere image tag ---
-# IDEMPIERE_IMAGE=idempiereofficial/idempiere:12-release
+# IDEMPIERE_IMAGE=idempiereofficial/idempiere:13-release
 
 # --- Postgres password (must match DB_ADMIN_PASS on iDempiere) ---
 # POSTGRES_PASSWORD=postgres

--- a/redis-cluster/Dockerfile.redis
+++ b/redis-cluster/Dockerfile.redis
@@ -1,0 +1,46 @@
+# Thin image FROM the public iDempiere v13-release that bakes in our
+# org.idempiere.redis.service bundle and registers it with the Equinox
+# simpleconfigurator so OSGi actually starts it.
+#
+# The bundle JAR comes from ./dropins/, populated by build-dropins.sh.
+# Default redis.yaml and redis.properties are baked in; both can be
+# overridden at runtime via single-file bind mounts in docker-compose.
+#
+# Build:   docker compose build      (or: docker build -f Dockerfile.redis -t idempiere-redis-cluster .)
+# Run:     handled by docker-compose.yml in this folder
+
+FROM idempiereofficial/idempiere:13-release
+
+USER root
+
+# Bake in the bundle JAR (file glob — exact filename varies with Tycho qualifier).
+COPY dropins/org.idempiere.redis.service-*.jar /tmp/redis-bundle.jar
+
+# Bake in default connection + tuning config (overridable via compose mounts).
+COPY config/redis.yaml /opt/idempiere/redis.yaml
+COPY config/redis.properties /opt/idempiere/redis.properties
+
+# 1) Read Bundle-Version from the JAR's MANIFEST so we don't have to hardcode
+#    the Tycho qualifier (the build timestamp suffix changes every build).
+# 2) Move the JAR into plugins/ using Eclipse naming (sym-name_version.jar)
+#    so it matches the convention of every other entry in bundles.info.
+# 3) Append a registration line so simpleconfigurator starts it at boot.
+#    start-level=4, auto-start=true   (mirrors how org.idempiere.hazelcast.service
+#    is registered, but eager — we want the higher-ranked redis ICacheService
+#    registered before the first cache lookup so it wins over hazelcast).
+RUN VER=$(unzip -p /tmp/redis-bundle.jar META-INF/MANIFEST.MF \
+            | tr -d '\r' \
+            | sed -n 's/^Bundle-Version: //p' \
+            | head -1) \
+ && [ -n "$VER" ] || (echo "Could not read Bundle-Version from redis-bundle.jar" >&2; exit 1) \
+ && BNAME="org.idempiere.redis.service_${VER}.jar" \
+ && mv /tmp/redis-bundle.jar "/opt/idempiere/plugins/$BNAME" \
+ && echo "org.idempiere.redis.service,${VER},plugins/${BNAME},4,true" \
+    >> /opt/idempiere/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info \
+ && chown idempiere:idempiere \
+      "/opt/idempiere/plugins/$BNAME" \
+      /opt/idempiere/redis.yaml \
+      /opt/idempiere/redis.properties \
+      /opt/idempiere/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info
+
+USER idempiere

--- a/redis-cluster/Dockerfile.redis
+++ b/redis-cluster/Dockerfile.redis
@@ -9,7 +9,8 @@
 # Build:   docker compose build      (or: docker build -f Dockerfile.redis -t idempiere-redis-cluster .)
 # Run:     handled by docker-compose.yml in this folder
 
-FROM idempiereofficial/idempiere:13-release
+ARG IDEMPIERE_IMAGE=idempiereofficial/idempiere:13-release
+FROM ${IDEMPIERE_IMAGE}
 
 USER root
 

--- a/redis-cluster/README.md
+++ b/redis-cluster/README.md
@@ -1,0 +1,128 @@
+# redis-cluster — IDEMPIERE-6989 distributed-cache test harness
+
+Two iDempiere nodes + one Redis + one Postgres. Validates the
+`org.idempiere.redis.service` bundle's clustering, cache invalidation,
+heartbeat membership, and circuit breaker against a real multi-node setup.
+
+The bundle being validated lives in the iDempiere fork at
+[github.com/cloudempiere/idempiere-fork](https://github.com/cloudempiere/idempiere-fork)
+on branch `IDEMPIERE-6989`. Upstream JIRA:
+[IDEMPIERE-6989](https://idempiere.atlassian.net/browse/IDEMPIERE-6989).
+
+## Prerequisites
+
+- Docker + docker-compose v2
+- Java 17 + Maven (only for building the bundle JAR — the iDempiere containers don't need it)
+- A local checkout of the iDempiere fork that includes the IDEMPIERE-6989 branch
+- ~6 GB free RAM (4 containers; iDempiere is ~1.5-2 GB each under load)
+- ~2 GB free disk for first-time image pulls
+
+## Quickstart
+
+```bash
+# 1. Build the bundle JAR and stage it in dropins/
+IDEMPIERE_SRC=~/GitHub/idempiere-fork bash build-dropins.sh
+
+# 2. Build the runtime image (bakes the bundle JAR + default config)
+docker compose build
+
+# 3. First-boot: bring up postgres + redis + node-a, wait for DB seed,
+#    then start node-b. The script sequences this for you so the two
+#    nodes don't race on the schema import.
+bash scripts/start.sh --seed
+
+# Subsequent boots just need:
+#    bash scripts/start.sh         # both nodes at once
+# Or vanilla compose (depends_on:service_healthy now sequences this):
+#    docker compose up -d
+
+# 4. Watch node-a come up (~3 min on first boot for DB seed)
+docker compose logs -f idempiere-a
+# Ready when:  "BundleEvent STARTED" for org.idempiere.webui
+#         AND  "org.idempiere.redis.service activated as the distributed backend"
+
+# 5. Open the webui (https, self-signed cert -> accept warning)
+#    node-a: https://localhost:8443/webui/
+#    node-b: https://localhost:8444/webui/
+#    Login:  GardenAdmin / GardenAdmin
+```
+
+## Validate clustering
+
+```bash
+# Heartbeat keys — expect 2 (one per node UUID), TTL 30s
+docker exec idmp-redis redis-cli --scan --pattern "idempiere:test-cluster:members:*"
+
+# Watch live cache traffic while editing a record in the webui
+docker exec idmp-redis redis-cli MONITOR
+
+# Cluster console (Equinox commands shipped by the bundle)
+docker exec -it idmp-a telnet localhost 12612
+# In the OSGi console:  redisStatus    - bundle activation state, key prefix, near-cache
+#                       redisHealth    - circuit-breaker state and consecutive failures
+#                       redisMembers   - live cluster members from heartbeat keys
+#                       redisKeys      - count Redis keys matching a glob (defaults to <prefix>*)
+#                       redisBound     - which backend is bound for ICacheService etc.
+#                       redisKeyspace  - keyspace notification subscriber state and event count
+```
+
+## Resilience tests
+
+```bash
+# Trip the circuit breaker
+docker compose stop redis
+docker compose logs -f --tail=50 idempiere-a | grep -i "circuit"
+# expect within ~5 failed calls:  "Redis circuit breaker tripped to OPEN after N consecutive failures"
+
+# Recover (probe-interval is 60s by default; probe runs on a background scheduler)
+docker compose start redis
+# expect within ~60s: "Redis circuit breaker recovered to CLOSED after probe"
+```
+
+## Tear down
+
+```bash
+docker compose down       # keeps DB + redis volumes (faster restart)
+docker compose down -v    # nukes everything; next start re-seeds the DB ~3 min
+```
+
+## Configuration
+
+`config/redis.yaml` — Redisson native YAML, mounted into both nodes at
+`/opt/idempiere/redis.yaml`. Currently configured for single-server topology
+pointing at the compose `redis` service. Switch to `sentinelServersConfig` or
+`clusterServersConfig` to test against managed Redis topologies.
+
+`config/redis.properties` — bundle-specific tuning (instance.name, Caffeine
+near-cache, circuit breaker), mounted at `/opt/idempiere/redis.properties`.
+Both nodes share the same `redis.instance.name=test-cluster` so they discover
+each other via heartbeat keys under the `idempiere:test-cluster:` prefix.
+
+`.env.example` — overridable environment (image tag, TZ, postgres password).
+Copy to `.env` to apply.
+
+## What's where
+
+| Path | Committed? | Purpose |
+|---|---|---|
+| `docker-compose.yml` | yes | 4-container stack definition |
+| `Dockerfile.redis` | yes | Image overlay on `idempiereofficial/idempiere:13-release` that bakes in the bundle JAR |
+| `config/redis.yaml` | yes | Redisson connection config |
+| `config/redis.properties` | yes | Bundle tuning |
+| `build-dropins.sh` | yes (executable) | Build bundle JAR from `$IDEMPIERE_SRC`, copy into `dropins/` |
+| `scripts/start.sh` | yes (executable) | Sequenced bring-up; `--seed` for first-boot, `--single` for postgres+redis+a only |
+| `scripts/stop.sh` | yes (executable) | Tear-down; `--wipe` also drops volumes |
+| `.env.example` | yes | Reference for overridable env vars |
+| `dropins/.gitkeep` | yes | Marker so the folder exists in git |
+| `dropins/*.jar` | gitignored | Built bundle JAR |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| iDempiere logs don't say "activated as the distributed backend" | `JAVA_OPTIONS` env didn't reach the JVM | `docker exec idmp-a env \| grep JAVA_OPTIONS` to verify |
+| `redis-cli --scan` returns no `idempiere:*` keys | Heartbeat thread didn't start, or `instance.name` mismatch | `docker exec idmp-a cat /opt/idempiere/redis.properties` |
+| Only ONE heartbeat key (not two) | Both nodes have different `instance.name` | Compare both containers — likely a volume-mount typo |
+| `https://localhost:8443/webui/` → connection refused | iDempiere still booting (DB seed) or container crashed | `docker compose logs idempiere-a` |
+| node-b takes 3 min to start (should be ~30s) | `MIGRATE_EXISTING_DATABASE` set to true, re-seeding the shared DB | Should be unset/false in compose |
+| Port collision on 5432 / 6380 / 8443 / 8444 / 12612 / 12613 | Host has a service running on that port | Stop conflicting service or change port mapping in compose |

--- a/redis-cluster/build-dropins.sh
+++ b/redis-cluster/build-dropins.sh
@@ -38,6 +38,11 @@ cp "$MANIFEST" "$MANIFEST.bak"
 trap 'mv "$MANIFEST.bak" "$MANIFEST" 2>/dev/null || true' EXIT
 
 echo "Patching MANIFEST.MF Require-Bundle floor 14.0.0 -> $TARGET_BASE_VERSION (build-time only, restored on exit)"
+if ! grep -qF 'org.adempiere.base;bundle-version="14.0.0"' "$MANIFEST"; then
+  echo "ERROR: expected 'org.adempiere.base;bundle-version=\"14.0.0\"' not found in $MANIFEST" >&2
+  echo "       Has the bundle's Require-Bundle floor changed? Update build-dropins.sh accordingly." >&2
+  exit 3
+fi
 sed "s/org\.adempiere\.base;bundle-version=\"14\.0\.0\"/org.adempiere.base;bundle-version=\"$TARGET_BASE_VERSION\"/" \
     "$MANIFEST" > "$MANIFEST.new"
 mv "$MANIFEST.new" "$MANIFEST"

--- a/redis-cluster/build-dropins.sh
+++ b/redis-cluster/build-dropins.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build the org.idempiere.redis.service bundle in your iDempiere source
+# checkout and stage the JAR in this folder's dropins/ for the Dockerfile
+# to bake into the runtime image.
+#
+# No v14 iDempiere docker image is published yet (your fork is on
+# 14.0.0-SNAPSHOT, but only v13-release ships publicly). We work around
+# this by lowering the bundle's Require-Bundle floor from 14.0.0 to 13.0.0
+# at build time only — the consumed APIs (org.idempiere.distributed.* SPI)
+# are stable across v12-v14, so this works at runtime. Your working tree's
+# MANIFEST.MF is restored regardless of build outcome (trap on EXIT), so
+# nothing leaks into commits.
+#
+# Bump TARGET_BASE_VERSION to 14.0.0 once a v14-release docker image ships.
+#
+# Usage:
+#   IDEMPIERE_SRC=/path/to/idempiere-fork bash build-dropins.sh
+
+set -euo pipefail
+
+: "${IDEMPIERE_SRC:?IDEMPIERE_SRC must point to your iDempiere source checkout (e.g. ~/GitHub/idempiere-fork)}"
+
+if [[ ! -d "$IDEMPIERE_SRC/org.idempiere.redis.service" ]]; then
+  echo "ERROR: $IDEMPIERE_SRC does not contain org.idempiere.redis.service/" >&2
+  echo "Make sure IDEMPIERE_SRC points at the iDempiere fork that has the bundle." >&2
+  exit 2
+fi
+
+DOCKER_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$IDEMPIERE_SRC/org.idempiere.redis.service/META-INF/MANIFEST.MF"
+TARGET_BASE_VERSION="13.0.0"
+
+if [[ "$(uname -s)" == "Darwin" ]] && [[ -z "${JAVA_HOME:-}" ]]; then
+  export JAVA_HOME="$(/usr/libexec/java_home -v 17)"
+fi
+
+cp "$MANIFEST" "$MANIFEST.bak"
+trap 'mv "$MANIFEST.bak" "$MANIFEST" 2>/dev/null || true' EXIT
+
+echo "Patching MANIFEST.MF Require-Bundle floor 14.0.0 -> $TARGET_BASE_VERSION (build-time only, restored on exit)"
+sed "s/org\.adempiere\.base;bundle-version=\"14\.0\.0\"/org.adempiere.base;bundle-version=\"$TARGET_BASE_VERSION\"/" \
+    "$MANIFEST" > "$MANIFEST.new"
+mv "$MANIFEST.new" "$MANIFEST"
+
+echo "Building redis bundle from $IDEMPIERE_SRC"
+cd "$IDEMPIERE_SRC"
+mvn -pl org.idempiere.p2.targetplatform,org.idempiere.redis.service \
+    clean verify -DskipTests
+
+echo "Refreshing $DOCKER_DIR/dropins/"
+mkdir -p "$DOCKER_DIR/dropins"
+rm -f "$DOCKER_DIR/dropins/org.idempiere.redis.service-"*.jar
+find "$IDEMPIERE_SRC/org.idempiere.redis.service/target" \
+     -maxdepth 1 -name "org.idempiere.redis.service-*.jar" \
+     ! -name "*-sources.jar" \
+     -exec cp {} "$DOCKER_DIR/dropins/" \;
+
+ls -lh "$DOCKER_DIR/dropins/"
+echo
+echo "Done. Built JAR has Require-Bundle floor $TARGET_BASE_VERSION; working tree MANIFEST.MF restored to 14.0.0."
+echo "Next: cd $DOCKER_DIR && docker compose build && bash scripts/start.sh --seed"

--- a/redis-cluster/build-dropins.sh
+++ b/redis-cluster/build-dropins.sh
@@ -31,7 +31,8 @@ MANIFEST="$IDEMPIERE_SRC/org.idempiere.redis.service/META-INF/MANIFEST.MF"
 TARGET_BASE_VERSION="13.0.0"
 
 if [[ "$(uname -s)" == "Darwin" ]] && [[ -z "${JAVA_HOME:-}" ]]; then
-  export JAVA_HOME="$(/usr/libexec/java_home -v 17)"
+  JAVA_HOME="$(/usr/libexec/java_home -v 17)"
+  export JAVA_HOME
 fi
 
 cp "$MANIFEST" "$MANIFEST.bak"

--- a/redis-cluster/config/redis.properties
+++ b/redis-cluster/config/redis.properties
@@ -1,0 +1,16 @@
+# IDEMPIERE-6989 redis backend tuning for the redis-cluster harness.
+# Mounted into both iDempiere containers at /opt/idempiere/redis.properties.
+# Both nodes share this file -> same instance.name -> one cluster scope.
+
+# Key-prefix scope. Both nodes use the same value so they discover each other
+# via heartbeat keys idempiere:test-cluster:members:*
+redis.instance.name=test-cluster
+
+# Caffeine near-cache (hot reads served in microseconds from JVM heap).
+near-cache.enabled=true
+near-cache.maxSize=10000
+near-cache.expireAfterWrite=PT5M
+
+# Circuit breaker: trip OPEN after N consecutive failures, probe every probe-interval.
+redis.circuit.failure-threshold=5
+redis.circuit.probe-interval=PT60S

--- a/redis-cluster/config/redis.yaml
+++ b/redis-cluster/config/redis.yaml
@@ -1,0 +1,17 @@
+# Redisson connection config for the IDEMPIERE-6989 redis-cluster harness.
+# Mounted into both iDempiere containers at /opt/idempiere/redis.yaml.
+# Both nodes share this file -> same Redis target -> one cluster.
+
+singleServerConfig:
+  address: "redis://redis:6379"
+  password: null
+  database: 0
+
+  connectionMinimumIdleSize: 24
+  connectionPoolSize: 64
+  subscriptionConnectionMinimumIdleSize: 1
+  subscriptionConnectionPoolSize: 50
+
+  timeout: 3000
+  retryAttempts: 3
+  retryInterval: 1500

--- a/redis-cluster/docker-compose.yml
+++ b/redis-cluster/docker-compose.yml
@@ -76,6 +76,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.redis
+      args:
+        IDEMPIERE_IMAGE: ${IDEMPIERE_IMAGE:-idempiereofficial/idempiere:13-release}
     image: idempiere-redis-cluster:local
     container_name: idmp-a
     depends_on:
@@ -104,7 +106,9 @@ services:
     healthcheck:
       # Webui returns 200 once iDempiere has finished bootstrapping.
       # start_period is generous (5 min) because first-boot runs RUN_ImportIdempiere.sh.
-      test: ["CMD-SHELL", "wget --no-check-certificate -q -O- https://localhost:8443/webui/ >/dev/null 2>&1 || exit 1"]
+      # Probe with whichever HTTP client is present in the base image.
+      # The 13-release image ships wget; curl is the fallback for variants that don't.
+      test: ["CMD-SHELL", "wget --no-check-certificate -qO- https://localhost:8443/webui/ >/dev/null 2>&1 || curl -fsSk https://localhost:8443/webui/ >/dev/null 2>&1 || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 30

--- a/redis-cluster/docker-compose.yml
+++ b/redis-cluster/docker-compose.yml
@@ -1,0 +1,147 @@
+name: idempiere-redis-cluster
+
+# Two iDempiere v13 nodes sharing one Postgres and one Redis.
+# Validates the org.idempiere.redis.service distributed-cache backend
+# (IDEMPIERE-6989) end-to-end on a single docker host.
+#
+# The iDempiere image is built locally from Dockerfile.redis and bakes in
+# the redis bundle JAR (staged by build-dropins.sh from your iDempiere
+# fork).  We do NOT bind-mount over /opt/idempiere/plugins — that would
+# shadow every stock OSGi bundle and break the entire framework.
+#
+# Quickstart:
+#   1. Build the bundle JAR:        IDEMPIERE_SRC=~/GitHub/idempiere-fork bash build-dropins.sh
+#   2. Build the runtime image:     docker compose build
+#   3. First-boot (sequenced):      bash scripts/start.sh --seed
+#   4. Subsequent boots:            bash scripts/start.sh
+#   5. Webuis:                      https://localhost:8443/webui (node-a)
+#                                   https://localhost:8444/webui (node-b)
+#
+# Tear down:
+#   bash scripts/stop.sh            keeps DB + redis volumes
+#   bash scripts/stop.sh --wipe     nukes everything
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: idmp-redis
+    command:
+      - redis-server
+      - --notify-keyspace-events
+      - Egx
+      - --appendonly
+      - "yes"
+    ports:
+      # Host 6380 -> container 6379. Host 6379 is taken by a local redis used
+      # by the Eclipse-launched iDempiere dev instance; keep them side-by-side.
+      # The two dockerized iDempiere nodes still reach redis via the internal
+      # docker network as redis://redis:6379 — this mapping only affects
+      # redis-cli access from the host.
+      - "6380:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - idmp-net
+
+  postgres:
+    image: postgres:16
+    container_name: idmp-postgres
+    # Leave POSTGRES_USER unset — the iDempiere image's startup script
+    # connects as the default 'postgres' superuser (DB_ADMIN_USER, hardcoded)
+    # using DB_ADMIN_PASS to create the 'adempiere' role and 'idempiere'
+    # database on first boot. Overriding POSTGRES_USER breaks that bootstrap.
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      TZ: ${TZ:-UTC}
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+    networks:
+      - idmp-net
+
+  idempiere-a: &idempiere-base
+    build:
+      context: .
+      dockerfile: Dockerfile.redis
+    image: idempiere-redis-cluster:local
+    container_name: idmp-a
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      TZ: ${TZ:-UTC}
+      DB_HOST: postgres
+      DB_NAME: idempiere
+      DB_USER: adempiere
+      DB_PASS: adempiere
+      DB_ADMIN_PASS: ${POSTGRES_PASSWORD:-postgres}
+      JAVA_OPTIONS: "-Didempiere.distributed.backend=redis"
+    volumes:
+      # Single-file bind mounts for runtime config — these don't shadow the
+      # parent dir, so the rest of /opt/idempiere stays intact.
+      - ./config/redis.yaml:/opt/idempiere/redis.yaml:ro
+      - ./config/redis.properties:/opt/idempiere/redis.properties:ro
+      - idempiere-a-config:/opt/idempiere/configuration
+      - idempiere-a-log:/opt/idempiere/log
+    ports:
+      - "8443:8443"
+      - "12612:12612"
+    healthcheck:
+      # Webui returns 200 once iDempiere has finished bootstrapping.
+      # start_period is generous (5 min) because first-boot runs RUN_ImportIdempiere.sh.
+      test: ["CMD-SHELL", "wget --no-check-certificate -q -O- https://localhost:8443/webui/ >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 30
+      start_period: 300s
+    restart: unless-stopped
+    networks:
+      - idmp-net
+
+  idempiere-b:
+    <<: *idempiere-base
+    container_name: idmp-b
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      idempiere-a:
+        # Wait for node-a to finish seeding the DB before node-b boots —
+        # otherwise both nodes try to import the schema simultaneously.
+        condition: service_healthy
+    volumes:
+      - ./config/redis.yaml:/opt/idempiere/redis.yaml:ro
+      - ./config/redis.properties:/opt/idempiere/redis.properties:ro
+      - idempiere-b-config:/opt/idempiere/configuration
+      - idempiere-b-log:/opt/idempiere/log
+    ports:
+      - "8444:8443"
+      - "12613:12612"
+
+volumes:
+  redis-data:
+  pg-data:
+  idempiere-a-config:
+  idempiere-a-log:
+  idempiere-b-config:
+  idempiere-b-log:
+
+networks:
+  idmp-net:
+    driver: bridge

--- a/redis-cluster/scripts/start.sh
+++ b/redis-cluster/scripts/start.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-MODE="${1:-full}"
+MODE="${1:---full}"
 
 case "$MODE" in
   --single)
@@ -48,7 +48,7 @@ case "$MODE" in
     docker compose up -d idempiere-b
     ;;
 
-  --full|"")
+  --full)
     echo "Starting full stack (both nodes at once — assumes DB already seeded)..."
     docker compose up -d
     ;;

--- a/redis-cluster/scripts/start.sh
+++ b/redis-cluster/scripts/start.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ============================================================
+# start.sh — bring up the redis-cluster harness
+# ============================================================
+# Usage:
+#   bash scripts/start.sh           # both nodes at once (post-first-boot)
+#   bash scripts/start.sh --single  # only postgres + redis + node-a
+#   bash scripts/start.sh --seed    # safe first-boot: node-a first, wait
+#                                   #   for it to seed DB, then node-b
+# ============================================================
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE="${1:-full}"
+
+case "$MODE" in
+  --single)
+    echo "Starting postgres + redis + idempiere-a only..."
+    docker compose up -d postgres redis idempiere-a
+    ;;
+
+  --seed)
+    echo "First-boot sequence: postgres + redis + node-a..."
+    docker compose up -d postgres redis idempiere-a
+    echo
+    echo "Waiting for idempiere-a to become healthy (DB seed can take 3-5 min)..."
+    while :; do
+      status=$(docker inspect -f '{{.State.Health.Status}}' idmp-a 2>/dev/null || echo starting)
+      case "$status" in
+        healthy)
+          echo "idempiere-a is healthy."
+          break
+          ;;
+        unhealthy)
+          echo "idempiere-a is UNHEALTHY. Last logs:"
+          docker compose logs --tail=50 idempiere-a
+          exit 1
+          ;;
+        *)
+          echo "  ...still waiting (status: $status)"
+          sleep 15
+          ;;
+      esac
+    done
+    echo "Starting node-b..."
+    docker compose up -d idempiere-b
+    ;;
+
+  --full|"")
+    echo "Starting full stack (both nodes at once — assumes DB already seeded)..."
+    docker compose up -d
+    ;;
+
+  *)
+    echo "Unknown option: $MODE" >&2
+    echo "Usage: $0 [--single|--seed|--full]" >&2
+    exit 1
+    ;;
+esac
+
+echo
+echo "Container status:"
+docker compose ps
+
+echo
+echo "Endpoints:"
+echo "  node-a webui    https://localhost:8443/webui"
+echo "  node-b webui    https://localhost:8444/webui"
+echo "  node-a console  telnet localhost 12612"
+echo "  node-b console  telnet localhost 12613"
+echo "  postgres        psql -h localhost -p 5432 -U postgres -d idempiere"
+echo "  redis           redis-cli -p 6380"
+echo
+echo "Tail logs with: docker compose logs -f idempiere-a"

--- a/redis-cluster/scripts/stop.sh
+++ b/redis-cluster/scripts/stop.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# ============================================================
+# stop.sh — bring down the redis-cluster harness
+# ============================================================
+# Usage:
+#   bash scripts/stop.sh          # stop containers, keep volumes
+#   bash scripts/stop.sh --wipe   # also delete pg-data, redis-data, etc.
+#                                 #   next --seed boot will re-import the DB (~3 min)
+# ============================================================
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE="${1:-}"
+
+case "$MODE" in
+  --wipe)
+    echo "Stopping stack and deleting all volumes..."
+    docker compose down -v
+    ;;
+  "")
+    echo "Stopping stack (volumes preserved)..."
+    docker compose down
+    ;;
+  *)
+    echo "Unknown option: $MODE" >&2
+    echo "Usage: $0 [--wipe]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6989

Two-node iDempiere v13 + Redis + Postgres stack for end-to-end validation of the org.idempiere.redis.service bundle (clustering, cache invalidation, heartbeat membership, circuit breaker) against a real multi-node setup.

- Dockerfile.redis: thin overlay on idempiereofficial/idempiere:13-release that bakes in the bundle JAR (read Bundle-Version from MANIFEST, install under plugins/, register with simpleconfigurator at start-level 4).
- docker-compose.yml: 2 nodes share one redis + one postgres, with depends_on:service_healthy sequencing the DB seed.
- build-dropins.sh: builds the bundle from \$IDEMPIERE_SRC and stages the JAR in dropins/ (with build-time MANIFEST patch lowering Require-Bundle floor 14.0.0 -> 13.0.0 since no v14 image is published yet; working tree restored on exit).
- scripts/start.sh, scripts/stop.sh: --seed first-boot, --wipe tear-down.
- config/redis.{yaml,properties}: defaults baked into the image, both overridable via single-file bind mounts.
- .gitignore: ignore the built bundle JAR in dropins/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Redis-backed two-node cluster harness for testing distributed cache scenarios
  * Local orchestration via Docker Compose with start/stop workflows and an image build for the Redis integration
  * Configurable Redis tuning and environment-variable defaults to simplify local overrides

* **Documentation**
  * Added a comprehensive README with quickstart, validation, resilience tests, teardown, and troubleshooting

* **Chores**
  * Updated ignores to exclude cluster drop-in JARs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->